### PR TITLE
Fix duplicate formControlName

### DIFF
--- a/frontend/src/app/components/projects/projects.component.html
+++ b/frontend/src/app/components/projects/projects.component.html
@@ -10,7 +10,7 @@
 
     <div class="mb-3">
       <label class="form-label">Description</label>
-      <textarea formControlName="description" formControlName="description" class="form-control" rows="2" placeholder="Project description"></textarea>
+      <textarea formControlName="description" class="form-control" rows="2" placeholder="Project description"></textarea>
     </div>
 
     <div class="d-flex gap-2">


### PR DESCRIPTION
## Summary
- remove duplicate formControlName attribute from textarea

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_687b9cb555688322942e3ff9885f0618