### PR TITLE
Remove unused bcryptjs package

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^6.0.0",
-        "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "dotenv": "^17.2.0",
         "express": "^5.1.0",
@@ -91,15 +90,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/bcryptjs": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
-      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
-      "license": "BSD-3-Clause",
-      "bin": {
-        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/binary-extensions": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,6 @@
   "type": "commonjs",
   "dependencies": {
     "bcrypt": "^6.0.0",
-    "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "dotenv": "^17.2.0",
     "express": "^5.1.0",


### PR DESCRIPTION
## Summary
- drop `bcryptjs` from the backend dependencies
- update `package-lock.json` via `npm install`

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_687b9ca5b8b883228bf4bb392c47a50a