### PR TITLE
Fix styleUrls property in about component

### DIFF
--- a/frontend/src/app/components/about/about.component.ts
+++ b/frontend/src/app/components/about/about.component.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
   selector: 'app-about',
   imports: [],
   templateUrl: './about.component.html',
-  styleUrl: './about.component.scss'
+  styleUrls: ['./about.component.scss']
 })
 export class AboutComponent {
 


### PR DESCRIPTION
## Summary
- fix property name from `styleUrl` to `styleUrls`

## Testing
- `npm --prefix frontend install`
- `npx --prefix frontend ng test --watch=false` *(fails: Property 'title' does not exist on type 'AppComponent')*

------
https://chatgpt.com/codex/tasks/task_e_687bae3f6a508322a1c9286ccd64cdab