### PR TITLE
Remove outdated title checks

### DIFF
--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -1,10 +1,17 @@
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
+import { AuthService } from './services/auth.service';
 
 describe('AppComponent', () => {
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+
   beforeEach(async () => {
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['isLoggedIn']);
+    authServiceSpy.isLoggedIn.and.returnValue(true);
+
     await TestBed.configureTestingModule({
       imports: [AppComponent],
+      providers: [{ provide: AuthService, useValue: authServiceSpy }]
     }).compileComponents();
   });
 
@@ -14,16 +21,10 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'projectmanager-frontend' title`, () => {
+  it('should delegate login state to AuthService', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('projectmanager-frontend');
-  });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, projectmanager-frontend');
+    expect(app.isLoggedIn()).toBeTrue();
+    expect(authServiceSpy.isLoggedIn).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- update `app.component.spec.ts` so tests use the component's public API rather than a removed `title` property

## Testing
- `npx ng test --no-watch --browsers=ChromeHeadlessNoSandbox` *(fails: ToastService has no provider for `ToastConfig`)*

------
https://chatgpt.com/codex/tasks/task_e_687bae4277c883229b6c8a749fe88e7e